### PR TITLE
Fixes to initializers and uploaders to allow migrations to run.

### DIFF
--- a/app/uploaders/logo_uploader.rb
+++ b/app/uploaders/logo_uploader.rb
@@ -8,7 +8,11 @@ class LogoUploader < CarrierWave::Uploader::Base
   end
 
   def self.choose_storage
-    (Rails.env.production? and Configuration[:aws_access_key]) ? :fog : :file
+    if Rails.env.production? && defined? Configuration
+      (Configuration[:aws_access_key]) ? :fog : :file
+    else
+      # We should be running initial migrations to be here. The Configuration model does not yet exist to be read from
+    end
   end
 
   storage choose_storage

--- a/app/uploaders/profile_image_uploader.rb
+++ b/app/uploaders/profile_image_uploader.rb
@@ -11,7 +11,11 @@ class ProfileImageUploader < CarrierWave::Uploader::Base
   end
 
   def self.choose_storage
-    (Rails.env.production? and Configuration[:aws_access_key]) ? :fog : :file
+    if Rails.env.production? && defined? Configuration
+      (Configuration[:aws_access_key]) ? :fog : :file
+    else
+      # We should be running initial migrations to be here. The Configuration model does not yet exist to be read from
+    end
   end
 
   storage choose_storage

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -1,13 +1,17 @@
 CarrierWave.configure do |config|
-  if Rails.env.production? and Configuration[:aws_access_key]
-    config.fog_credentials = {
-      provider: 'AWS',
-      aws_access_key_id: Configuration[:aws_access_key],
-      aws_secret_access_key: Configuration[:aws_secret_key]
-    }
-    config.fog_directory  = Configuration[:aws_bucket]
-    config.fog_attributes = {'Cache-Control'=>'max-age=315576000'}  # optional, defaults to {}
+  if Rails.env.production? and defined? Configuration
+    if Configuration[:aws_access_key]
+      config.fog_credentials = {
+        provider: 'AWS',
+        aws_access_key_id: Configuration[:aws_access_key],
+        aws_secret_access_key: Configuration[:aws_secret_key]
+      }
+      config.fog_directory  = Configuration[:aws_bucket]
+      config.fog_attributes = {'Cache-Control'=>'max-age=315576000'}  # optional, defaults to {}
+    else
+      config.enable_processing = false if Rails.env.test? or Rails.env.cucumber?
+    end
   else
-    config.enable_processing = false if Rails.env.test? or Rails.env.cucumber?
+    # We should be running initial migrations to be here. The Configuration model does not yet exist to be read from.
   end
 end

--- a/config/initializers/default_url_options.rb
+++ b/config/initializers/default_url_options.rb
@@ -1,4 +1,4 @@
-if Rails.env.production?
+if Rails.env.production? && defined? Configuration
   Rails.application.routes.default_url_options = {host: ::Configuration[:host]} 
 else
   Rails.application.routes.default_url_options = {host: 'localhost:3000'} 

--- a/config/initializers/mailchimp.rb
+++ b/config/initializers/mailchimp.rb
@@ -1,2 +1,6 @@
 # Comment this out when running rake db:migrate for the first time
-MAILCHIMP_API_KEY = Configuration[:mailchimp_api_key]
+if defined? Configuration
+  MAILCHIMP_API_KEY = Configuration[:mailchimp_api_key]
+else
+  # We should be running initial migrations to be here. The Configuration model does not yet exist to be read from.
+end

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,9 +1,13 @@
 # Be sure to restart your server when you modify this file.
 
-if Rails.env.production? && Configuration[:base_domain]
-  Catarse::Application.config.session_store :cookie_store, key: '_catarse_session', domain: Configuration[:base_domain]
+if Rails.env.production? && defined? Configuration
+  if Configuration[:base_domain]
+    Catarse::Application.config.session_store :cookie_store, key: '_catarse_session', domain: Configuration[:base_domain]
+  else
+    Catarse::Application.config.session_store :cookie_store, key: '_catarse_session'
+  end
 else
-  Catarse::Application.config.session_store :cookie_store, key: '_catarse_session'
+  # We should be running initial migrations to be here. The Configuration model does not yet exist to be read from.
 end
 
 # Use the database for sessions instead of the cookie-based default,


### PR DESCRIPTION
Wrapped initializers and uploader classes to test for existence of Configuration model before attempting access.  This allows initial migrations to run without issue.  Migrations contain PostgreSQL specific code that requires PostgreSQL 9.4!